### PR TITLE
Update handler.js

### DIFF
--- a/handler.js
+++ b/handler.js
@@ -6,7 +6,10 @@ var queryString = require('query-string');
 module.exports.requestUploadURL = (event, context, callback) => {
 
   // Create new S3 instance to handle our request for a new upload URL.
-  var s3 = new AWS.S3();
+  // Using signatureVersion v4 allows authenticating inbound API requests to AWS services.
+  const s3 = new AWS.S3({
+    signatureVersion: 'v4'
+  });
 
   // Parse out the parameters of the file the client would like to upload.
   var params = queryString.parse(event.body)


### PR DESCRIPTION
I was getting errors in my curl PUT requests using the signedURL. (error: The AWS Access Key Id you provided does not exist in our records.) Using signatureVersion v4 fixed this.